### PR TITLE
Fix windows compatibility

### DIFF
--- a/bricklayers.py
+++ b/bricklayers.py
@@ -2035,8 +2035,10 @@ Argument names are case-insensitive, so:
 
 
     def gcode_opener(path, flags):
-        file=os.open(path, flags)
-        header=os.pread(file,4,0)
+        file = os.open(path, flags)
+        header = os.read(file, 4)
+        # Set cursor back to the start
+        os.lseek(file, 0, os.SEEK_SET)
         if header==bytes("GCDE","ascii"):
             os.close(file) #do not leak the file descriptor
             print(f"{error_marker}The file '{input_file}' is a binary gcode file, which is not supported. Disable Binary G-code in your slicer settings", file=sys.stderr)


### PR DESCRIPTION
- The `os.pread` function [is only available on unix-like operating systems](https://docs.python.org/3/library/os.html#os.pread), making the current code not work on windows
- This patch replaces the `pread` function call with calls to `os.read` and `os.lseek` to set the cursor position back to the start of the file, emulating the same behavior in this instance

Note: I personally would probably avoid using the `opener` function overwrite to validate the file and instead simply check the file header after opening it normally. Imo that would be a bit more straight forward and you avoid dealing with the raw filedescriptors with the raw read functions. Anyway, that would just be my personal preference.

In general, very cool project!🔥