### PR TITLE
Docker: containerized deployment option

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,28 @@
+name: build and publish docker
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push the image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/386,linux/amd64,linux/arm64/v8,windows/amd64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USER }}/bricklayers:latest
+            ${{ secrets.DOCKERHUB_USER }}/bricklayers:${{github.ref_name}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM pypy:latest
+
+WORKDIR /src/app
+COPY bricklayers.py .
+ENTRYPOINT ["python", "bricklayers.py"]


### PR DESCRIPTION
Added a minimal `Dockerfile` and build/publish workflow so users don't have to install and update Python on their system.
Images available on [dockerhub](https://hub.docker.com/r/dubhar/bricklayers).

If you try to use the workflow yourself, add repository secrets:
- `DOCKERHUB_USER`
- `DOCKERHUB_PASSWORD`