### PR TITLE
fix: Prevent Travel Fix Up injection inside wipe blocks

### DIFF
--- a/bricklayers.py
+++ b/bricklayers.py
@@ -2013,7 +2013,7 @@ class BrickLayersProcessor:
                     buffer_lines.append(myline)
 
                 self.last_noninternalperimeter_state = current_state
-                if simulator.moved_in_xy:
+                if simulator.moved_in_xy and not feature.wiping:
                     myline.current = current_state
                     self.last_noninternalperimeter_xy_line = myline
 


### PR DESCRIPTION
## Bambu Studio Wipe Fix

Fixes missing chunks in Bambu Studio's G-code preview and improves print quality at brick layer transitions.

### Problem

BrickLayers stores a reference to the last non-internal-perimeter travel line (`last_noninternalperimeter_xy_line`) and later replaces it with a `Travel Fix Up` move that includes a Z change. When this travel line happens to be inside a `WIPE_START`/`WIPE_END` block, the replacement breaks the wipe sequence.

This causes:
1. **Missing chunks in Bambu Studio's G-code preview** — the renderer can't parse the malformed wipe sequence
2. **Incomplete nozzle wipe at brick layer transitions** — the wipe path is interrupted, potentially causing strings or blobs

### Fix

One-line change: added `and not feature.wiping` check when storing the travel line reference. This prevents BrickLayers from modifying travel moves that are part of a wipe sequence.

```python
# Before:
if simulator.moved_in_xy:

# After:
if simulator.moved_in_xy and not feature.wiping:
```

### Impact

- **Bambu Studio format:** Fixes missing chunks in preview and print quality at transitions
- **OrcaSlicer format:** No change (OrcaSlicer's wipe handling doesn't produce the same travel pattern inside wipe blocks)
- **Print quality:** The wipe sequence now completes correctly, ensuring proper nozzle cleaning before layer transitions

### Slicer Preview

A [patched BambuStudio fork](https://github.com/adele-with-a-b/BambuStudio/tree/post-process-preview) is available that re-parses G-code after post-processing scripts run, showing the BrickLayers toolpath directly in the preview without manual re-import. This wipe fix is required for the preview to render correctly.