### PR TITLE
fix: Correct G92 E reset after deferred perimeters (issue #17)

### DIFF
--- a/bricklayers.py
+++ b/bricklayers.py
@@ -1610,7 +1610,8 @@ class BrickLayersProcessor:
                             # If the gcode was using absolute extrusion, insert an M82 to return to Absolute Extrusion
                             buffer.append(from_gcode("M82 ; BRICK: Return to Absolute Extrusion\n"))
                             # Resets the correct absolute extrusion register for the next feature:
-                            buffer.append(from_gcode(f"G92 E{myline.previous.e} ; BRICK: Resets the Extruder absolute position\n"))
+                            e_reset = self.last_noninternalperimeter_state.e if self.last_noninternalperimeter_state else myline.previous.e
+                            buffer.append(from_gcode(f"G92 E{e_reset} ; BRICK: Resets the Extruder absolute position\n"))
                         ##########
 
                         if previous_perimeter != perimeter_index:
@@ -1937,7 +1938,8 @@ class BrickLayersProcessor:
                             # If the gcode was using absolute extrusion, insert an M82 to return to Absolute Extrusion
                             buffer_lines.append(from_gcode("M82 ; BRICK: Return to Absolute Extrusion\n"))
                             # Resets the correct absolute extrusion register for the next feature:
-                            buffer_lines.append(from_gcode(f"G92 E{myline.previous.e} ; BRICK: Resets the Extruder absolute position\n"))
+                            e_reset = self.last_noninternalperimeter_state.e if self.last_noninternalperimeter_state else myline.previous.e
+                            buffer_lines.append(from_gcode(f"G92 E{e_reset} ; BRICK: Resets the Extruder absolute position\n"))
                         self.last_internalperimeter_state = calculated_line.current
                         #if  myline.previous.width != kept_line.current.width:
                         buffer_lines.append(from_gcode(f"{simulator.const_width}{myline.previous.width}\n"))   # For the Preview


### PR DESCRIPTION
## Absolute Extrusion Fix

In absolute extrusion mode (used by PrusaSlicer), the `G92 E` reset after deferred perimeters used `myline.previous.e` — the E value that **includes** the deferred perimeters' extrusion. But since those perimeters were replayed with relative extrusion (M83), the firmware's E register never advanced by that amount.

This caused a massive blob at the start of the next feature (outer wall) as reported in #17.

### Fix

`G92 E` now uses `self.last_noninternalperimeter_state.e` — the E value from **before** the deferred perimeters. Applied to both `generate_deffered_perimeters()` and the kept perimeters path.

```python
# Before:
buffer.append(from_gcode(f"G92 E{myline.previous.e} ..."))

# After:
e_reset = self.last_noninternalperimeter_state.e if self.last_noninternalperimeter_state else myline.previous.e
buffer.append(from_gcode(f"G92 E{e_reset} ..."))
```

### Impact

- **PrusaSlicer** (absolute extrusion): Fixes blob at layer transitions
- **Bambu Studio / OrcaSlicer** (relative extrusion): No-op — these slicers use M83 by default

Closes #17